### PR TITLE
[feat] 걱정 저장 API 생성

### DIFF
--- a/hackathon/src/main/java/org/sopt/hackathon/common/dto/SuccessMessage.java
+++ b/hackathon/src/main/java/org/sopt/hackathon/common/dto/SuccessMessage.java
@@ -12,6 +12,7 @@ public enum SuccessMessage {
     MEMBER_CREATE_SUCCESS(HttpStatus.CREATED.value(), "멤버 생성이 럭키쌈뽕하게 완료되었습니다."),
     LUCKY_ANSWER_SUCCESS(HttpStatus.OK.value(), "럭키럭키 체인지가 성공하다니 완전 럭키비키잖앙🍀"),
     MEMBER_FIND_SUCCESS(HttpStatus.OK.value(), "멤버 조회가 럭키쌈뽕하게 성공했습니다."),
+    CONCERN_CREATE_SUCCESS(HttpStatus.CREATED.value(), "걱정 생성이 럭키쌈뽕하게 완료되었습니다."),
 
     ;
 

--- a/hackathon/src/main/java/org/sopt/hackathon/controller/ConcernController.java
+++ b/hackathon/src/main/java/org/sopt/hackathon/controller/ConcernController.java
@@ -1,0 +1,40 @@
+package org.sopt.hackathon.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.sopt.hackathon.common.dto.SuccessMessage;
+import org.sopt.hackathon.common.dto.SuccessStatusResponse;
+import org.sopt.hackathon.dto.ConcernCreateDto;
+import org.sopt.hackathon.service.ConcernService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/concerns")
+public class ConcernController {
+
+    private final ConcernService concernService;
+
+    @Operation(summary = "걱정 생성", description = """
+            걱정 등록에 성공하면
+            "201 Created 걱정 생성이 럭키쌈뽕하게 완료되었습니다." 반환
+            concernId 반환
+            """)
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public SuccessStatusResponse createConcern(
+            @RequestHeader(value = "memberId") Long memberId,
+            @RequestBody ConcernCreateDto concernCreateDto
+    ) {
+        return SuccessStatusResponse.of(SuccessMessage.CONCERN_CREATE_SUCCESS.getStatus(),
+                SuccessMessage.CONCERN_CREATE_SUCCESS.getMessage(),
+                concernService.createConcern(memberId, concernCreateDto));
+    }
+
+}

--- a/hackathon/src/main/java/org/sopt/hackathon/domain/Concern.java
+++ b/hackathon/src/main/java/org/sopt/hackathon/domain/Concern.java
@@ -31,6 +31,6 @@ public class Concern {
     @Builder
     public Concern(String content, Member member) {
         this.content = content;
-
+        this.member = member;
     }
 }

--- a/hackathon/src/main/java/org/sopt/hackathon/dto/ConcernCreateDto.java
+++ b/hackathon/src/main/java/org/sopt/hackathon/dto/ConcernCreateDto.java
@@ -1,0 +1,6 @@
+package org.sopt.hackathon.dto;
+
+public record ConcernCreateDto(
+        String content
+) {
+}

--- a/hackathon/src/main/java/org/sopt/hackathon/dto/ConcernPostResponseDto.java
+++ b/hackathon/src/main/java/org/sopt/hackathon/dto/ConcernPostResponseDto.java
@@ -1,0 +1,12 @@
+package org.sopt.hackathon.dto;
+
+import org.sopt.hackathon.domain.Concern;
+
+public record ConcernPostResponseDto(Long concernId) {
+
+    public static ConcernPostResponseDto of(Concern concern) {
+
+        return new ConcernPostResponseDto(concern.getId());
+    }
+    
+}

--- a/hackathon/src/main/java/org/sopt/hackathon/service/ConcernService.java
+++ b/hackathon/src/main/java/org/sopt/hackathon/service/ConcernService.java
@@ -1,0 +1,32 @@
+package org.sopt.hackathon.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.hackathon.domain.Concern;
+import org.sopt.hackathon.dto.ConcernCreateDto;
+import org.sopt.hackathon.dto.ConcernPostResponseDto;
+import org.sopt.hackathon.repository.ConcernRepository;
+import org.sopt.hackathon.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ConcernService {
+
+    private final ConcernRepository concernRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public ConcernPostResponseDto createConcern(
+            Long memberId,
+            ConcernCreateDto concernCreateDto
+    ) {
+
+        Concern concern = Concern.builder()
+                .content(concernCreateDto.content())
+                .member(memberRepository.findById(memberId).get())
+                .build();
+
+        return ConcernPostResponseDto.of(concernRepository.save(concern));
+    }
+}

--- a/hackathon/src/main/java/org/sopt/hackathon/service/MemberService.java
+++ b/hackathon/src/main/java/org/sopt/hackathon/service/MemberService.java
@@ -24,8 +24,9 @@ public class MemberService {
         return MemberPostResponseDto.of(member);
     }
 
+    @Transactional
     public MemberFindDto findMemberById(Long memberId) {
         return MemberFindDto.of(memberRepository.findById(memberId).get());
     }
-    
+
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #6 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
걱정 저장 API 를 생성했습니다.
memberId 를 header 로 받고 걱정을 저장합니다!
걱정(content) 는 body로 받습니다.
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
![image](https://github.com/sopkathon-android-team-4/Android-BE/assets/107605573/30ffa7f2-9e9a-41f7-a806-a57e6f39082d)
![image](https://github.com/sopkathon-android-team-4/Android-BE/assets/107605573/0f2a8c28-2952-4be2-94f9-785c114f5ef2)
**걱정 생성 결과**

